### PR TITLE
Prefix labels with kind/

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	// commentRE strips HTML comments so example code isn’t parsed.
+	// commentRE strips HTML comments so example code isn't parsed.
 	commentRE = regexp.MustCompile(`(?s)<!--.*?-->`)
 	// kindRE captures /kind labels, case-insensitive.
 	kindRE = regexp.MustCompile(`(?i)/kind\s+([a-z0-9_/-]+)`)
@@ -92,19 +92,21 @@ func main() {
 
 			// add missing and remove stale labels
 			for k := range kinds {
-				if currentMap[k] {
+				kindLabel := "kind/" + k
+				if currentMap[kindLabel] {
 					continue
 				}
-				_, _, err := client.Issues.AddLabelsToIssue(ctx, owner, repo, prNum, []string{k})
+				_, _, err := client.Issues.AddLabelsToIssue(ctx, owner, repo, prNum, []string{kindLabel})
 				if err != nil {
-					return fmt.Errorf("failed to add label %q: %w", k, err)
+					return fmt.Errorf("failed to add label %q: %w", kindLabel, err)
 				}
 			}
 			for label := range currentMap {
-				if !kindRE.MatchString("/kind " + label) {
+				if !strings.HasPrefix(label, "kind/") {
 					continue
 				}
-				if kinds[label] {
+				kindType := strings.TrimPrefix(label, "kind/")
+				if kinds[kindType] {
 					continue
 				}
 				_, err := client.Issues.RemoveLabelForIssue(ctx, owner, repo, prNum, label)


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

This change makes the kind labels more organized and clearer by prefixing them
with "kind/" (e.g., "kind/cleanup" instead of just "cleanup"). This helps
reduce confusion about what these labels represent and makes them more
consistent with common GitHub label naming conventions.

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bug_fix
/kind design
/kind cleanup
/kind deprecation
/kind documentation
/kind flake
/kind new_feature
```
-->

/kind breaking_change

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
This change makes the kind labels more organized and clearer by prefixing them
with "kind/" (e.g., "kind/cleanup" instead of just "cleanup")
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->

See https://github.com/kgateway-dev/kgateway/pull/11204.