### PR TITLE
Remove release-note-invalid label when valid release note is added

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	// commentRE strips HTML comments so example code isn’t parsed.
+	// commentRE strips HTML comments so example code isn't parsed.
 	commentRE = regexp.MustCompile(`(?s)<!--.*?-->`)
 	// kindRE captures /kind labels, case-insensitive.
 	kindRE = regexp.MustCompile(`(?i)/kind\s+([a-z0-9_/-]+)`)
@@ -128,8 +128,9 @@ func main() {
 				client.Issues.RemoveLabelForIssue(ctx, owner, repo, prNum, "release-note-needed")
 				return nil
 			}
-			// Else, valid entry. Mark release-note-needed so changelog generation automation
+			// Else, valid entry. Remove invalid label and mark release-note-needed so changelog generation automation
 			// can query for this PR easily.
+			client.Issues.RemoveLabelForIssue(ctx, owner, repo, prNum, "release-note-invalid")
 			client.Issues.AddLabelsToIssue(ctx, owner, repo, prNum, []string{"release-note-needed"})
 
 			return nil


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

Previously, when a PR was updated with a valid release note, the release-note-invalid label would remain even though the issue was fixed. This change ensures the invalid label is properly removed when a valid release note is detected.

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bug_fix
/kind design
/kind cleanup
/kind deprecation
/kind documentation
/kind flake
/kind new_feature
```
-->

/kind bug_fix

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
Previously, when a PR was updated with a valid release note, the release-note-invalid label would remain even though the issue was fixed. This change ensures the invalid label is properly removed when a valid release note is detected.
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->

See https://github.com/kgateway-dev/pr-kind-labeler/pull/2.