### PR TITLE
Rename release-notes-needed -> release-notes

### DIFF
--- a/main.go
+++ b/main.go
@@ -119,21 +119,21 @@ func main() {
 			match := releaseNoteRE.FindStringSubmatch(sanitizedBody)
 			if len(match) < 2 || strings.TrimSpace(match[1]) == "" {
 				// Missing or empty => invalid
-				client.Issues.AddLabelsToIssue(ctx, owner, repo, prNum, []string{"release-note-invalid"})
+				client.Issues.AddLabelsToIssue(ctx, owner, repo, prNum, []string{"do-not-merge/release-note-invalid"})
 				return fmt.Errorf("missing or empty ```release-note``` block; please add your line or 'NONE'")
 			}
 			// Handle the special case "NONE" scenario for changelog types that don't require release
 			// notes. Remove any stale labels.
 			entry := strings.TrimSpace(match[1])
 			if strings.EqualFold(entry, "NONE") {
-				client.Issues.RemoveLabelForIssue(ctx, owner, repo, prNum, "release-note-invalid")
-				client.Issues.RemoveLabelForIssue(ctx, owner, repo, prNum, "release-note-needed")
+				client.Issues.AddLabelsToIssue(ctx, owner, repo, prNum, []string{"release-note-none"})
+				client.Issues.RemoveLabelForIssue(ctx, owner, repo, prNum, "do-not-merge/release-note-invalid")
 				return nil
 			}
-			// Else, valid entry. Remove invalid label and mark release-note-needed so changelog generation automation
+			// Else, valid entry. Remove invalid label and mark release-note so changelog generation automation
 			// can query for this PR easily.
-			client.Issues.RemoveLabelForIssue(ctx, owner, repo, prNum, "release-note-invalid")
-			client.Issues.AddLabelsToIssue(ctx, owner, repo, prNum, []string{"release-note-needed"})
+			client.Issues.AddLabelsToIssue(ctx, owner, repo, prNum, []string{"release-note"})
+			client.Issues.RemoveLabelForIssue(ctx, owner, repo, prNum, "do-not-merge/release-note-invalid")
 
 			return nil
 		},

--- a/main.go
+++ b/main.go
@@ -56,8 +56,8 @@ func main() {
 			supportedKinds := map[string]bool{
 				"design":          true,
 				"deprecation":     true,
-				"new_feature":     true,
-				"bug_fix":         true,
+				"feature":         true,
+				"fix":             true,
 				"breaking_change": true,
 				"documentation":   true,
 				"cleanup":         true,

--- a/main.go
+++ b/main.go
@@ -74,7 +74,7 @@ func main() {
 				if supportedKinds[k] {
 					continue
 				}
-				if _, _, err := client.Issues.AddLabelsToIssue(ctx, owner, repo, prNum, []string{"do-not-merge"}); err != nil {
+				if _, _, err := client.Issues.AddLabelsToIssue(ctx, owner, repo, prNum, []string{"do-not-merge/kind-invalid"}); err != nil {
 					return fmt.Errorf("failed to add do-not-merge label: %w", err)
 				}
 				return fmt.Errorf("invalid /kind %q detected, labeling do-not-merge", k)


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

Several breaking changes:

1. Rename the new_feature -> feature kind type
2. Rename the bug_fix -> fix kind type
3. Rename release-notes-needed -> release-notes

- Previously the release-notes-needed label was awkardly named and signaled a PR description was incorrectly filled out
- Now the label has been renamed to release-note to avoid any confusion
- Similarly, prefix the release-notes-invalid label with do-not-merge to be consistent with how validation handles invalid kind types

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bug_fix
/kind design
/kind cleanup
/kind deprecation
/kind documentation
/kind flake
/kind new_feature
```
-->

/kind breaking_change

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
Renames the supported kind types new_feature and bug_fix to feature and fix respectively. Rename release-notes-needed -> release-notes as it was awkwardly named and implies the PR description was incorrectly filled out. 
```

