### PR TITLE
internal/labeler: Validate a kind type has been supplied

### DIFF
--- a/internal/labeler/labeler.go
+++ b/internal/labeler/labeler.go
@@ -107,6 +107,10 @@ func (l *labeler) extractKinds(body string) map[string]bool {
 
 // verifyKinds checks if all extracted kinds are supported
 func (l *labeler) verifyKinds(kinds map[string]bool) error {
+	if len(kinds) == 0 {
+		l.labelsToAdd["do-not-merge/kind-invalid"] = true
+		return fmt.Errorf("no /kind labels found, labeling do-not-merge/kind-invalid")
+	}
 	for k := range kinds {
 		if supportedKinds[k] {
 			continue

--- a/internal/labeler/labeler_test.go
+++ b/internal/labeler/labeler_test.go
@@ -15,6 +15,24 @@ import (
 	"github.com/migueleliasweb/go-github-mock/src/mock"
 )
 
+func TestProcessPR_NoKindSupplied(t *testing.T) {
+	// note: no need to mock the labels, as the labeler will exit early if no
+	// kind is supplied and no labels are added.
+	httpClient := mock.NewMockedHTTPClient(
+		mock.WithRequestMatch(
+			mock.GetReposIssuesLabelsByOwnerByRepoByIssueNumber,
+			[]*github.Label{},
+		),
+	)
+
+	c := github.NewClient(httpClient)
+	l := New(c, "foo", "bar", 42)
+	err := l.ProcessPR(context.Background(), "```release-note\nOK\n```")
+	if err == nil || !strings.Contains(err.Error(), "no /kind") {
+		t.Fatalf("expected an error when no kind is supplied, got %v", err)
+	}
+}
+
 func TestProcessPR_InvalidKind(t *testing.T) {
 	// note: no need to mock the labels, as the labeler will exit early if the
 	// kind is invalid and no labels are added.


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

test: Add case for no /kind, revealing incorrect label addition

Introduces TestProcessPR_NoKindSupplied to verify behavior when a PR
lacks a /kind command.

This test highlights an issue where a 'release-note' label is
erroneously processed and attempted to be added to the PR, even
when no /kind is specified, before an error for the missing
/kind is reported.

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bug_fix
/kind design
/kind cleanup
/kind deprecation
/kind documentation
/kind flake
/kind new_feature
```
-->

/kind fix

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
Fixed a bug where the labeler incorrectly marked a PR description missing a /kind entry as valid. Now, an error is returned indicating at least one /kind entry needs to be supplied.
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
