### PR TITLE
internal/labeler: Refactor error handling to avoid exiting early

### DIFF
--- a/internal/labeler/labeler.go
+++ b/internal/labeler/labeler.go
@@ -63,13 +63,18 @@ func (l *labeler) ProcessPR(ctx context.Context, body string) error {
 	}
 	// strip HTML comments to make the body easier to parse.
 	sanitizedBody := commentRE.ReplaceAllString(body, "")
+
+	var errs []error
 	if err := l.processKindLabels(sanitizedBody); err != nil {
-		return err
+		errs = append(errs, err)
 	}
 	if err := l.processReleaseNotes(sanitizedBody); err != nil {
-		return err
+		errs = append(errs, err)
 	}
-	return l.syncLabels(ctx)
+	if err := l.syncLabels(ctx); err != nil {
+		errs = append(errs, err)
+	}
+	return errors.Join(errs...)
 }
 
 // fetchLabels fetches the current labels for the PR

--- a/internal/labeler/labeler.go
+++ b/internal/labeler/labeler.go
@@ -154,26 +154,51 @@ func (l *labeler) syncKindLabels(kinds map[string]bool) error {
 
 // processReleaseNotes handles the release note validation and labeling
 func (l *labeler) processReleaseNotes(body string) error {
+	// if the release note bracket is missing, add the invalid label and remove any
+	// stale release-note or release-note-none labels.
 	match := releaseNoteRE.FindStringSubmatch(body)
-	if len(match) < 2 || strings.TrimSpace(match[1]) == "" {
+	if len(match) < 2 {
 		l.labelsToAdd["do-not-merge/release-note-invalid"] = true
+		if l.currentMap["release-note"] {
+			l.labelsToRemove["release-note"] = true
+		}
+		if l.currentMap["release-note-none"] {
+			l.labelsToRemove["release-note-none"] = true
+		}
 		return fmt.Errorf("missing or empty ```release-note``` block; please add your line or 'NONE'")
 	}
-
-	// trim the release note entry and check if it's the special "NONE" entry.
+	// otherwise, attempt to parse the release note.
 	entry := strings.TrimSpace(match[1])
-	if strings.EqualFold(entry, "NONE") {
+	switch {
+	case entry == "":
+		// handle the empty case. set the invalid label and remove the release-note label.
+		l.labelsToAdd["do-not-merge/release-note-invalid"] = true
+		if l.currentMap["release-note"] {
+			l.labelsToRemove["release-note"] = true
+		}
+		if l.currentMap["release-note-none"] {
+			l.labelsToRemove["release-note-none"] = true
+		}
+		return fmt.Errorf("missing or empty ```release-note``` block; please add your line or 'NONE'")
+	case strings.EqualFold(entry, "NONE"):
+		// handle the NONE case. set the none label and remove the invalid label and release-note label.
 		l.labelsToAdd["release-note-none"] = true
 		if l.currentMap["do-not-merge/release-note-invalid"] {
 			l.labelsToRemove["do-not-merge/release-note-invalid"] = true
 		}
-		return nil
-	}
-
-	// Valid entry, add the release-note label and remove the invalid label if it exists.
-	l.labelsToAdd["release-note"] = true
-	if l.currentMap["do-not-merge/release-note-invalid"] {
-		l.labelsToRemove["do-not-merge/release-note-invalid"] = true
+		if l.currentMap["release-note"] {
+			l.labelsToRemove["release-note"] = true
+		}
+	default:
+		// otherwise, a valid release note was found. set the release-note label and remove the invalid
+		// and none labels.
+		l.labelsToAdd["release-note"] = true
+		if l.currentMap["do-not-merge/release-note-invalid"] {
+			l.labelsToRemove["do-not-merge/release-note-invalid"] = true
+		}
+		if l.currentMap["release-note-none"] {
+			l.labelsToRemove["release-note-none"] = true
+		}
 	}
 	return nil
 }

--- a/internal/labeler/labeler_test.go
+++ b/internal/labeler/labeler_test.go
@@ -5,8 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"reflect"
-	"slices"
 	"sort"
 	"strings"
 	"testing"
@@ -16,12 +16,42 @@ import (
 )
 
 func TestProcessPR_NoKindSupplied(t *testing.T) {
-	// note: no need to mock the labels, as the labeler will exit early if no
-	// kind is supplied and no labels are added.
+	expectedLabelsToAdd := []string{"do-not-merge/kind-invalid", "release-note"}
+	sort.Strings(expectedLabelsToAdd)
+	expectedLabelsToRemove := []string{}
+
+	var actualLabelsAdded []string = make([]string, 0)
+	var actualLabelsRemoved []string = make([]string, 0)
+
 	httpClient := mock.NewMockedHTTPClient(
 		mock.WithRequestMatch(
 			mock.GetReposIssuesLabelsByOwnerByRepoByIssueNumber,
 			[]*github.Label{},
+		),
+		mock.WithRequestMatchHandler(
+			mock.PostReposIssuesLabelsByOwnerByRepoByIssueNumber,
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if err := json.NewDecoder(r.Body).Decode(&actualLabelsAdded); err != nil {
+					t.Fatalf("AddLabels Handler: failed to decode body: %v", err)
+				}
+				sort.Strings(actualLabelsAdded)
+				responseLabels := make([]*github.Label, len(actualLabelsAdded))
+				for i, name := range actualLabelsAdded {
+					responseLabels[i] = &github.Label{Name: github.Ptr(name)}
+				}
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(responseLabels)
+			}),
+		),
+		// Add a handler for delete, even if we expect no removals, to capture any unexpected ones
+		mock.WithRequestMatchHandler(
+			mock.DeleteReposIssuesLabelsByOwnerByRepoByIssueNumberByName,
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				parts := strings.Split(r.URL.Path, "/")
+				labelName := parts[len(parts)-1]
+				actualLabelsRemoved = append(actualLabelsRemoved, labelName)
+				w.WriteHeader(http.StatusNoContent)
+			}),
 		),
 	)
 
@@ -31,46 +61,23 @@ func TestProcessPR_NoKindSupplied(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "no /kind") {
 		t.Fatalf("expected an error when no kind is supplied, got %v", err)
 	}
+	if !reflect.DeepEqual(actualLabelsAdded, expectedLabelsToAdd) {
+		t.Fatalf("Expected labels to be added %v, got %v", expectedLabelsToAdd, actualLabelsAdded)
+	}
+	sort.Strings(actualLabelsRemoved)
+	if !reflect.DeepEqual(actualLabelsRemoved, expectedLabelsToRemove) {
+		t.Fatalf("Expected labels to be removed %v, got %v", expectedLabelsToRemove, actualLabelsRemoved)
+	}
 }
 
 func TestProcessPR_InvalidKind(t *testing.T) {
-	// note: no need to mock the labels, as the labeler will exit early if the
-	// kind is invalid and no labels are added.
-	httpClient := mock.NewMockedHTTPClient(
-		mock.WithRequestMatch(
-			mock.GetReposIssuesLabelsByOwnerByRepoByIssueNumber,
-			[]*github.Label{},
-		),
-	)
-	c := github.NewClient(httpClient)
-	l := New(c, "foo", "bar", 42)
-	err := l.ProcessPR(context.Background(), "/kind banana\n```release-note\nOK\n```")
-	if err == nil || !strings.Contains(err.Error(), "invalid /kind") {
-		t.Fatalf("expected kind-invalid error, got %v", err)
-	}
-}
+	expectedLabelsToAdd := []string{"do-not-merge/kind-invalid", "release-note"}
+	sort.Strings(expectedLabelsToAdd)
+	expectedLabelsToRemove := []string{}
 
-func TestProcessPR_ValidKind_InvalidReleaseNote(t *testing.T) {
-	// note: no need to mock the labels, as the labeler will exit early if the
-	// release note is invalid and no labels are added.
-	httpClient := mock.NewMockedHTTPClient(
-		mock.WithRequestMatch(
-			mock.GetReposIssuesLabelsByOwnerByRepoByIssueNumber,
-			[]*github.Label{{Name: github.Ptr("kind/fix")}},
-		),
-	)
-	l := New(github.NewClient(httpClient), "foo", "bar", 45)
-	err := l.ProcessPR(context.Background(), "/kind fix\n```release-note\n\n```")
-	if err == nil || !strings.Contains(err.Error(), "missing or empty") {
-		t.Fatalf("expected missing release-note error, got %v", err)
-	}
-}
+	var actualLabelsAdded []string = make([]string, 0)
+	var actualLabelsRemoved []string = make([]string, 0)
 
-func TestProcessPR_ValidKindAndReleaseNote(t *testing.T) {
-	expectedLabelsToAdd := []*github.Label{
-		{Name: github.Ptr("kind/feature")},
-		{Name: github.Ptr("release-note")},
-	}
 	httpClient := mock.NewMockedHTTPClient(
 		mock.WithRequestMatch(
 			mock.GetReposIssuesLabelsByOwnerByRepoByIssueNumber,
@@ -79,161 +86,12 @@ func TestProcessPR_ValidKindAndReleaseNote(t *testing.T) {
 		mock.WithRequestMatchHandler(
 			mock.PostReposIssuesLabelsByOwnerByRepoByIssueNumber,
 			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				var labelsSentForAddition []string
-				if err := json.NewDecoder(r.Body).Decode(&labelsSentForAddition); err != nil {
-					t.Fatalf("failed to decode request body: %v", err)
+				if err := json.NewDecoder(r.Body).Decode(&actualLabelsAdded); err != nil {
+					t.Fatalf("AddLabels Handler: failed to decode body: %v", err)
 				}
-				expectedLabelNames := make([]string, len(expectedLabelsToAdd))
-				for i, label := range expectedLabelsToAdd {
-					expectedLabelNames[i] = *label.Name
-				}
-				if len(labelsSentForAddition) != len(expectedLabelNames) {
-					t.Fatalf("expected %d labels to be sent for addition, got %d. Expected: %v, Got: %v", len(expectedLabelNames), len(labelsSentForAddition), expectedLabelNames, labelsSentForAddition)
-				}
-				for _, expectedName := range expectedLabelNames {
-					if slices.Contains(labelsSentForAddition, expectedName) {
-						continue
-					}
-					t.Fatalf("expected label %s to be sent for addition, but it was not. Sent: %v", expectedName, labelsSentForAddition)
-				}
-				w.Header().Set("Content-Type", "application/json")
-				json.NewEncoder(w).Encode(expectedLabelsToAdd)
-			}),
-		),
-	)
-	l := New(github.NewClient(httpClient), "foo", "bar", 43)
-	err := l.ProcessPR(context.Background(), "/kind feature\n```release-note\nNew feature implemented\n```")
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
-}
-
-func TestProcessPR_MultipleKinds(t *testing.T) {
-	expectedLabelsToAdd := []*github.Label{
-		{Name: github.Ptr("kind/feature")},
-		{Name: github.Ptr("kind/cleanup")},
-		{Name: github.Ptr("release-note")},
-	}
-	httpClient := mock.NewMockedHTTPClient(
-		mock.WithRequestMatch(
-			mock.GetReposIssuesLabelsByOwnerByRepoByIssueNumber,
-			[]*github.Label{},
-		),
-		mock.WithRequestMatchHandler(
-			mock.PostReposIssuesLabelsByOwnerByRepoByIssueNumber,
-			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				var labelsSentForAddition []string
-				if err := json.NewDecoder(r.Body).Decode(&labelsSentForAddition); err != nil {
-					t.Fatalf("failed to decode request body: %v", err)
-				}
-				expectedLabelNames := make([]string, len(expectedLabelsToAdd))
-				for i, label := range expectedLabelsToAdd {
-					expectedLabelNames[i] = *label.Name
-				}
-				if len(labelsSentForAddition) != len(expectedLabelNames) {
-					t.Fatalf("expected %d labels to be sent for addition, got %d. Expected: %v, Got: %v", len(expectedLabelNames), len(labelsSentForAddition), expectedLabelNames, labelsSentForAddition)
-				}
-				for _, expectedName := range expectedLabelNames {
-					if slices.Contains(labelsSentForAddition, expectedName) {
-						continue
-					}
-					t.Fatalf("expected label %s to be sent for addition, but it was not. Sent: %v", expectedName, labelsSentForAddition)
-				}
-				w.Header().Set("Content-Type", "application/json")
-				json.NewEncoder(w).Encode(expectedLabelsToAdd)
-			}),
-		),
-	)
-	l := New(github.NewClient(httpClient), "foo", "bar", 44)
-	err := l.ProcessPR(context.Background(), "/kind feature\n/kind cleanup\n```release-note\nCleanup and feature\n```")
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
-}
-
-func TestProcessPR_ReleaseNoteNone(t *testing.T) {
-	expectedLabelToAdd := []*github.Label{
-		{Name: github.Ptr("release-note-none")},
-		{Name: github.Ptr("kind/cleanup")},
-	}
-	httpClient := mock.NewMockedHTTPClient(
-		mock.WithRequestMatch(
-			mock.GetReposIssuesLabelsByOwnerByRepoByIssueNumber,
-			[]*github.Label{},
-		),
-		mock.WithRequestMatchHandler(
-			mock.PostReposIssuesLabelsByOwnerByRepoByIssueNumber,
-			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				var labelsSentForAddition []string
-				if err := json.NewDecoder(r.Body).Decode(&labelsSentForAddition); err != nil {
-					t.Fatalf("failed to decode request body for add: %v", err)
-				}
-				for _, label := range expectedLabelToAdd {
-					if slices.Contains(labelsSentForAddition, *label.Name) {
-						continue
-					}
-					t.Fatalf("expected label %s to be sent for addition, but it was not. Sent: %v", *label.Name, labelsSentForAddition)
-				}
-				w.Header().Set("Content-Type", "application/json")
-				json.NewEncoder(w).Encode(expectedLabelToAdd)
-			}),
-		),
-		mock.WithRequestMatchHandler(
-			mock.DeleteReposIssuesLabelsByOwnerByRepoByIssueNumberByName,
-			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				fmt.Println("DeleteReposIssuesLabelsByOwnerByRepoByIssueNumberByName", r.Body)
-				w.WriteHeader(http.StatusNoContent)
-			}),
-		),
-	)
-	l := New(github.NewClient(httpClient), "foo", "bar", 46)
-	err := l.ProcessPR(context.Background(), "/kind cleanup\n```release-note\nNONE\n```")
-	if err != nil {
-		t.Fatalf("expected no error on NONE, got %v", err)
-	}
-}
-
-func TestProcessPR_EditedToInvalid(t *testing.T) {
-	// note: no need to mock the labels, as the labeler will exit early if the
-	// release note is invalid and no labels are added
-	httpClient := mock.NewMockedHTTPClient(
-		mock.WithRequestMatch(
-			mock.GetReposIssuesLabelsByOwnerByRepoByIssueNumber,
-			[]*github.Label{
-				{Name: github.Ptr("kind/fix")},
-				{Name: github.Ptr("release-note")},
-			},
-		),
-	)
-
-	l := New(github.NewClient(httpClient), "foo", "bar", 47)
-	err := l.ProcessPR(context.Background(), "/kind fix\nNo release-note here")
-	if err == nil || !strings.Contains(err.Error(), "missing or empty ```release-note``` block") {
-		t.Fatalf("ProcessPR error expected to contain 'missing or empty ```release-note``` block', got: %v", err.Error())
-	}
-}
-
-func TestProcessPR_EditedToValid(t *testing.T) {
-	expectedLabelsToBeAdded := []string{"kind/fix", "release-note"}
-	sort.Strings(expectedLabelsToBeAdded)
-
-	httpClient := mock.NewMockedHTTPClient(
-		mock.WithRequestMatch(
-			mock.GetReposIssuesLabelsByOwnerByRepoByIssueNumber,
-			[]*github.Label{{Name: github.Ptr("do-not-merge/release-note-invalid")}},
-		),
-		mock.WithRequestMatchHandler(
-			mock.PostReposIssuesLabelsByOwnerByRepoByIssueNumber,
-			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				var labelsBeingAdded []string
-				if err := json.NewDecoder(r.Body).Decode(&labelsBeingAdded); err != nil {
-					t.Fatalf("AddLabels Handler (expecting %v): failed to decode body: %v", expectedLabelsToBeAdded, err)
-				}
-				if !reflect.DeepEqual(labelsBeingAdded, expectedLabelsToBeAdded) {
-					t.Fatalf("AddLabels Handler: expected %v, got %v", expectedLabelsToBeAdded, labelsBeingAdded)
-				}
-				responseLabels := make([]*github.Label, len(labelsBeingAdded))
-				for i, name := range labelsBeingAdded {
+				sort.Strings(actualLabelsAdded)
+				responseLabels := make([]*github.Label, len(actualLabelsAdded))
+				for i, name := range actualLabelsAdded {
 					responseLabels[i] = &github.Label{Name: github.Ptr(name)}
 				}
 				w.Header().Set("Content-Type", "application/json")
@@ -243,17 +101,355 @@ func TestProcessPR_EditedToValid(t *testing.T) {
 		mock.WithRequestMatchHandler(
 			mock.DeleteReposIssuesLabelsByOwnerByRepoByIssueNumberByName,
 			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if !strings.Contains(r.URL.Path, "do-not-merge/release-note-invalid") {
-					t.Fatalf("expected label to be removed, got %v", r.URL.Path)
+				parts := strings.Split(r.URL.Path, "/")
+				labelName := parts[len(parts)-1]
+				actualLabelsRemoved = append(actualLabelsRemoved, labelName)
+				w.WriteHeader(http.StatusNoContent)
+			}),
+		),
+	)
+	c := github.NewClient(httpClient)
+	l := New(c, "foo", "bar", 42)
+	err := l.ProcessPR(context.Background(), "/kind banana\n```release-note\nOK\n```")
+	if err == nil || !strings.Contains(err.Error(), "invalid /kind") {
+		t.Fatalf("expected kind-invalid error, got %v", err)
+	}
+	if !reflect.DeepEqual(actualLabelsAdded, expectedLabelsToAdd) {
+		t.Fatalf("Expected labels to be added %v, got %v", expectedLabelsToAdd, actualLabelsAdded)
+	}
+	sort.Strings(actualLabelsRemoved)
+	if !reflect.DeepEqual(actualLabelsRemoved, expectedLabelsToRemove) {
+		t.Fatalf("Expected labels to be removed %v, got %v", expectedLabelsToRemove, actualLabelsRemoved)
+	}
+}
+
+func TestProcessPR_ValidKind_InvalidReleaseNote(t *testing.T) {
+	expectedLabelsToAdd := []string{"kind/fix", "do-not-merge/release-note-invalid"}
+	sort.Strings(expectedLabelsToAdd)
+	expectedLabelsToRemove := []string{}
+
+	var actualLabelsAdded []string = make([]string, 0)
+	var actualLabelsRemoved []string = make([]string, 0)
+
+	httpClient := mock.NewMockedHTTPClient(
+		mock.WithRequestMatch(
+			mock.GetReposIssuesLabelsByOwnerByRepoByIssueNumber,
+			// No initial labels on the PR for this test case
+			[]*github.Label{},
+		),
+		mock.WithRequestMatchHandler(
+			mock.PostReposIssuesLabelsByOwnerByRepoByIssueNumber,
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if err := json.NewDecoder(r.Body).Decode(&actualLabelsAdded); err != nil {
+					t.Fatalf("AddLabels Handler: failed to decode body: %v", err)
 				}
+				sort.Strings(actualLabelsAdded)
+				responseLabels := make([]*github.Label, len(actualLabelsAdded))
+				for i, name := range actualLabelsAdded {
+					responseLabels[i] = &github.Label{Name: github.Ptr(name)}
+				}
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(responseLabels)
+			}),
+		),
+		mock.WithRequestMatchHandler(
+			mock.DeleteReposIssuesLabelsByOwnerByRepoByIssueNumberByName,
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				parts := strings.Split(r.URL.Path, "/")
+				labelName := parts[len(parts)-1]
+				actualLabelsRemoved = append(actualLabelsRemoved, labelName)
+				w.WriteHeader(http.StatusNoContent)
+			}),
+		),
+	)
+	l := New(github.NewClient(httpClient), "foo", "bar", 45)
+	err := l.ProcessPR(context.Background(), "/kind fix\n```release-note\n\n```")
+	if err == nil || !strings.Contains(err.Error(), "missing or empty") {
+		t.Fatalf("expected missing release-note error, got %v", err)
+	}
+	if !reflect.DeepEqual(actualLabelsAdded, expectedLabelsToAdd) {
+		t.Fatalf("Expected labels to be added %v, got %v", expectedLabelsToAdd, actualLabelsAdded)
+	}
+	sort.Strings(actualLabelsRemoved)
+	if !reflect.DeepEqual(actualLabelsRemoved, expectedLabelsToRemove) {
+		t.Fatalf("Expected labels to be removed %v, got %v", expectedLabelsToRemove, actualLabelsRemoved)
+	}
+}
+
+func TestProcessPR_ValidKindAndReleaseNote(t *testing.T) {
+	expectedLabelsToAdd := []string{"kind/feature", "release-note"}
+	sort.Strings(expectedLabelsToAdd)
+	expectedLabelsToRemove := []string{}
+
+	var actualLabelsAdded []string = make([]string, 0)
+	var actualLabelsRemoved []string = make([]string, 0)
+
+	httpClient := mock.NewMockedHTTPClient(
+		mock.WithRequestMatch(
+			mock.GetReposIssuesLabelsByOwnerByRepoByIssueNumber,
+			[]*github.Label{},
+		),
+		mock.WithRequestMatchHandler(
+			mock.PostReposIssuesLabelsByOwnerByRepoByIssueNumber,
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if err := json.NewDecoder(r.Body).Decode(&actualLabelsAdded); err != nil {
+					t.Fatalf("AddLabels Handler: failed to decode body: %v", err)
+				}
+				sort.Strings(actualLabelsAdded)
+				// Respond with the labels that were "added" as github.Label pointers
+				responseGithubLabels := make([]*github.Label, len(actualLabelsAdded))
+				for i, name := range actualLabelsAdded {
+					responseGithubLabels[i] = &github.Label{Name: github.Ptr(name)}
+				}
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(responseGithubLabels)
+			}),
+		),
+		mock.WithRequestMatchHandler(
+			mock.DeleteReposIssuesLabelsByOwnerByRepoByIssueNumberByName,
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				parts := strings.Split(r.URL.Path, "/")
+				labelName := parts[len(parts)-1]
+				actualLabelsRemoved = append(actualLabelsRemoved, labelName)
+				w.WriteHeader(http.StatusNoContent)
+			}),
+		),
+	)
+	l := New(github.NewClient(httpClient), "foo", "bar", 43)
+	err := l.ProcessPR(context.Background(), "/kind feature\n```release-note\nNew feature implemented\n```")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !reflect.DeepEqual(actualLabelsAdded, expectedLabelsToAdd) {
+		t.Fatalf("Expected labels to be added %v, got %v", expectedLabelsToAdd, actualLabelsAdded)
+	}
+	sort.Strings(actualLabelsRemoved)
+	if !reflect.DeepEqual(actualLabelsRemoved, expectedLabelsToRemove) {
+		t.Fatalf("Expected labels to be removed %v, got %v", expectedLabelsToRemove, actualLabelsRemoved)
+	}
+}
+
+func TestProcessPR_MultipleKinds(t *testing.T) {
+	expectedLabelsToAdd := []string{"kind/feature", "kind/cleanup", "release-note"}
+	sort.Strings(expectedLabelsToAdd)
+	expectedLabelsToRemove := []string{}
+
+	var actualLabelsAdded []string = make([]string, 0)
+	var actualLabelsRemoved []string = make([]string, 0)
+
+	httpClient := mock.NewMockedHTTPClient(
+		mock.WithRequestMatch(
+			mock.GetReposIssuesLabelsByOwnerByRepoByIssueNumber,
+			[]*github.Label{},
+		),
+		mock.WithRequestMatchHandler(
+			mock.PostReposIssuesLabelsByOwnerByRepoByIssueNumber,
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if err := json.NewDecoder(r.Body).Decode(&actualLabelsAdded); err != nil {
+					t.Fatalf("AddLabels Handler: failed to decode body: %v", err)
+				}
+				sort.Strings(actualLabelsAdded)
+				responseGithubLabels := make([]*github.Label, len(actualLabelsAdded))
+				for i, name := range actualLabelsAdded {
+					responseGithubLabels[i] = &github.Label{Name: github.Ptr(name)}
+				}
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(responseGithubLabels)
+			}),
+		),
+		mock.WithRequestMatchHandler(
+			mock.DeleteReposIssuesLabelsByOwnerByRepoByIssueNumberByName,
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				parts := strings.Split(r.URL.Path, "/")
+				labelName := parts[len(parts)-1]
+				actualLabelsRemoved = append(actualLabelsRemoved, labelName)
+				w.WriteHeader(http.StatusNoContent)
+			}),
+		),
+	)
+	l := New(github.NewClient(httpClient), "foo", "bar", 44)
+	err := l.ProcessPR(context.Background(), "/kind feature\n/kind cleanup\n```release-note\nCleanup and feature\n```")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !reflect.DeepEqual(actualLabelsAdded, expectedLabelsToAdd) {
+		t.Fatalf("Expected labels to be added %v, got %v", expectedLabelsToAdd, actualLabelsAdded)
+	}
+	sort.Strings(actualLabelsRemoved)
+	if !reflect.DeepEqual(actualLabelsRemoved, expectedLabelsToRemove) {
+		t.Fatalf("Expected labels to be removed %v, got %v", expectedLabelsToRemove, actualLabelsRemoved)
+	}
+}
+
+func TestProcessPR_ReleaseNoteNone(t *testing.T) {
+	expectedLabelsToAdd := []string{"kind/cleanup", "release-note-none"}
+	sort.Strings(expectedLabelsToAdd)
+	expectedLabelsToRemove := []string{}
+
+	var actualLabelsAdded []string = make([]string, 0)
+	var actualLabelsRemoved []string = make([]string, 0)
+
+	httpClient := mock.NewMockedHTTPClient(
+		mock.WithRequestMatch(
+			mock.GetReposIssuesLabelsByOwnerByRepoByIssueNumber,
+			[]*github.Label{},
+		),
+		mock.WithRequestMatchHandler(
+			mock.PostReposIssuesLabelsByOwnerByRepoByIssueNumber,
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if err := json.NewDecoder(r.Body).Decode(&actualLabelsAdded); err != nil {
+					t.Fatalf("AddLabels Handler: failed to decode body: %v", err)
+				}
+				sort.Strings(actualLabelsAdded)
+				responseGithubLabels := make([]*github.Label, len(actualLabelsAdded))
+				for i, name := range actualLabelsAdded {
+					responseGithubLabels[i] = &github.Label{Name: github.Ptr(name)}
+				}
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(responseGithubLabels)
+			}),
+		),
+		mock.WithRequestMatchHandler(
+			mock.DeleteReposIssuesLabelsByOwnerByRepoByIssueNumberByName,
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				parts := strings.Split(r.URL.Path, "/")
+				labelName := parts[len(parts)-1]
+				actualLabelsRemoved = append(actualLabelsRemoved, labelName)
+				w.WriteHeader(http.StatusNoContent)
+			}),
+		),
+	)
+	l := New(github.NewClient(httpClient), "foo", "bar", 46)
+	err := l.ProcessPR(context.Background(), "/kind cleanup\n```release-note\nNONE\n```")
+	if err != nil {
+		t.Fatalf("expected no error on NONE, got %v", err)
+	}
+	if !reflect.DeepEqual(actualLabelsAdded, expectedLabelsToAdd) {
+		t.Fatalf("Expected labels to be added %v, got %v", expectedLabelsToAdd, actualLabelsAdded)
+	}
+	sort.Strings(actualLabelsRemoved)
+	if !reflect.DeepEqual(actualLabelsRemoved, expectedLabelsToRemove) {
+		t.Fatalf("Expected labels to be removed %v, got %v", expectedLabelsToRemove, actualLabelsRemoved)
+	}
+}
+
+func TestProcessPR_EditedToInvalid(t *testing.T) {
+	expectedLabelsToAdd := []string{"do-not-merge/release-note-invalid"}
+	sort.Strings(expectedLabelsToAdd)
+
+	expectedLabelsToRemove := []string{"release-note"}
+	sort.Strings(expectedLabelsToRemove)
+
+	var actualLabelsAdded []string = make([]string, 0)
+	var actualLabelsRemoved []string = make([]string, 0)
+
+	httpClient := mock.NewMockedHTTPClient(
+		mock.WithRequestMatch(
+			mock.GetReposIssuesLabelsByOwnerByRepoByIssueNumber,
+			[]*github.Label{
+				{Name: github.Ptr("kind/fix")},
+				{Name: github.Ptr("release-note")},
+			},
+		),
+		mock.WithRequestMatchHandler(
+			mock.PostReposIssuesLabelsByOwnerByRepoByIssueNumber,
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if err := json.NewDecoder(r.Body).Decode(&actualLabelsAdded); err != nil {
+					t.Fatalf("AddLabels Handler: failed to decode body: %v", err)
+				}
+				sort.Strings(actualLabelsAdded)
+				responseLabels := make([]*github.Label, len(actualLabelsAdded))
+				for i, name := range actualLabelsAdded {
+					responseLabels[i] = &github.Label{Name: github.Ptr(name)}
+				}
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(responseLabels)
+			}),
+		),
+		mock.WithRequestMatchHandler(
+			mock.DeleteReposIssuesLabelsByOwnerByRepoByIssueNumberByName,
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				pathPrefix := fmt.Sprintf("/repos/%s/%s/issues/%d/labels/", "foo", "bar", 47)
+				labelNameSegment := strings.TrimPrefix(r.URL.Path, pathPrefix)
+				decodedLabelName, err := url.PathUnescape(labelNameSegment)
+				if err != nil {
+					t.Fatalf("Failed to unescape label name segment '%s': %v", labelNameSegment, err)
+				}
+				actualLabelsRemoved = append(actualLabelsRemoved, decodedLabelName)
 				w.WriteHeader(http.StatusNoContent)
 			}),
 		),
 	)
 
 	l := New(github.NewClient(httpClient), "foo", "bar", 47)
-	err := l.ProcessPR(context.Background(), "/kind fix\n```release-note\nFixed it\n```")
+	err := l.ProcessPR(context.Background(), "/kind fix\nNo release-note here")
+	if err == nil || !strings.Contains(err.Error(), "missing or empty ```release-note``` block") {
+		t.Fatalf("ProcessPR error expected to contain 'missing or empty ```release-note``` block', got: %v", err.Error())
+	}
+	if !reflect.DeepEqual(actualLabelsAdded, expectedLabelsToAdd) {
+		t.Fatalf("Expected labels to be added %v, got %v", expectedLabelsToAdd, actualLabelsAdded)
+	}
+	sort.Strings(actualLabelsRemoved)
+	if !reflect.DeepEqual(actualLabelsRemoved, expectedLabelsToRemove) {
+		t.Fatalf("Expected labels to be removed %v, got %v", expectedLabelsToRemove, actualLabelsRemoved)
+	}
+}
+
+func TestProcessPR_EditedToValid(t *testing.T) {
+	expectedLabelsToAdd := []string{"kind/fix", "release-note"}
+	sort.Strings(expectedLabelsToAdd)
+	expectedLabelsToRemove := []string{"do-not-merge/release-note-invalid"}
+	sort.Strings(expectedLabelsToRemove)
+
+	var actualLabelsAdded []string = make([]string, 0)
+	var actualLabelsRemoved []string = make([]string, 0)
+
+	httpClient := mock.NewMockedHTTPClient(
+		mock.WithRequestMatch(
+			mock.GetReposIssuesLabelsByOwnerByRepoByIssueNumber,
+			[]*github.Label{{Name: github.Ptr("do-not-merge/release-note-invalid")}},
+		),
+		mock.WithRequestMatchHandler(
+			mock.PostReposIssuesLabelsByOwnerByRepoByIssueNumber,
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if err := json.NewDecoder(r.Body).Decode(&actualLabelsAdded); err != nil {
+					t.Fatalf("AddLabels Handler: failed to decode body: %v", err)
+				}
+				sort.Strings(actualLabelsAdded)
+				responseGithubLabels := make([]*github.Label, len(actualLabelsAdded))
+				for i, name := range actualLabelsAdded {
+					responseGithubLabels[i] = &github.Label{Name: github.Ptr(name)}
+				}
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(responseGithubLabels)
+			}),
+		),
+		mock.WithRequestMatchHandler(
+			mock.DeleteReposIssuesLabelsByOwnerByRepoByIssueNumberByName,
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				pathPrefix := fmt.Sprintf("/repos/%s/%s/issues/%d/labels/", "foo", "bar", 47)
+				labelNameSegment := strings.TrimPrefix(r.URL.Path, pathPrefix)
+				decodedLabelName, err := url.PathUnescape(labelNameSegment)
+				if err != nil {
+					t.Fatalf("Failed to unescape label name segment '%s': %v", labelNameSegment, err)
+				}
+				actualLabelsRemoved = append(actualLabelsRemoved, decodedLabelName)
+				w.WriteHeader(http.StatusNoContent)
+			}),
+		),
+	)
+
+	l := New(github.NewClient(httpClient), "foo", "bar", 47)
+	err := l.ProcessPR(context.Background(), "/kind fix\\n```release-note\\nFixed it\\n```")
 	if err != nil {
 		t.Fatalf("expected no error from ProcessPR, got %v", err)
+	}
+
+	if !reflect.DeepEqual(actualLabelsAdded, expectedLabelsToAdd) {
+		t.Fatalf("Expected labels to be added %v, got %v", expectedLabelsToAdd, actualLabelsAdded)
+	}
+	sort.Strings(actualLabelsRemoved)
+	if !reflect.DeepEqual(actualLabelsRemoved, expectedLabelsToRemove) {
+		t.Fatalf("Expected labels to be removed %v, got %v", expectedLabelsToRemove, actualLabelsRemoved)
 	}
 }


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

Refactor how the internal/labeler package handles errors. Previously, if an invalid kind or release note was detected, the labeler would return an error and avoid syncing the labels. Now, the errors are batched until the labels have been synced before being joined together in the main driver method.

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bug_fix
/kind design
/kind cleanup
/kind deprecation
/kind documentation
/kind flake
/kind new_feature
```
-->

/kind fix

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
Fix the labeler's logic to ensure that labels are synced on validation errors. Previously, the labeler would exit early on kind or release note validation errors, preventing any labels (including error indication labels like 'do-not-merge/kind-invalid') from being synced. Now, label syncing always occurs and validation errors are collected and returned after the attempt to sync all the determined label additions and removals.
```
