### PR TITLE
internal/labeler: Sync the do-not-merge/kind-invalid label correctly

### DIFF
--- a/internal/labeler/labeler.go
+++ b/internal/labeler/labeler.go
@@ -124,15 +124,22 @@ func (l *labeler) extractKinds(body string) map[string]bool {
 // verifyKinds checks if all extracted kinds are supported
 func (l *labeler) verifyKinds(kinds map[string]bool) error {
 	if len(kinds) == 0 {
-		l.labelsToAdd["do-not-merge/kind-invalid"] = true
+		if !l.currentMap["do-not-merge/kind-invalid"] {
+			l.labelsToAdd["do-not-merge/kind-invalid"] = true
+		}
 		return fmt.Errorf("no /kind labels found, labeling do-not-merge/kind-invalid")
 	}
 	for k := range kinds {
 		if supportedKinds[k] {
 			continue
 		}
-		l.labelsToAdd["do-not-merge/kind-invalid"] = true
+		if !l.currentMap["do-not-merge/kind-invalid"] {
+			l.labelsToAdd["do-not-merge/kind-invalid"] = true
+		}
 		return fmt.Errorf("invalid /kind %q detected, labeling do-not-merge/kind-invalid", k)
+	}
+	if l.currentMap["do-not-merge/kind-invalid"] {
+		l.labelsToRemove["do-not-merge/kind-invalid"] = true
 	}
 	return nil
 }


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

The labeler was previously not removing the "do-not-merge/kind-invalid" label if a PR was updated from an invalid/missing kind state to a valid kind state.

This commit updates the `verifyKinds` function to explicitly mark "do-not-merge/kind-invalid" for removal if it exists on a PR and the kinds specified in the PR body are determined to be valid.

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bug_fix
/kind design
/kind cleanup
/kind deprecation
/kind documentation
/kind flake
/kind new_feature
```
-->

/kind fix

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
The labeler was previously not removing the "do-not-merge/kind-invalid" label if a PR was updated from an invalid/missing kind state to a valid kind state. Now, this label is removed if it exists on a PR and the kinds specified in the PR body are determined to be valid.
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
