### PR TITLE
internal/labeler: Fix references to the release-notes-needed label

### DIFF
--- a/internal/labeler/labeler.go
+++ b/internal/labeler/labeler.go
@@ -177,10 +177,10 @@ func (l *labeler) syncKindLabels(kinds map[string]bool) error {
 
 // processReleaseNotes handles the release note validation and labeling
 func (l *labeler) processReleaseNotes(body string) error {
-	// temporary migration: if the deprecated release-notes-needed label exists, remove it
+	// temporary migration: if the deprecated release-note-needed label exists, remove it
 	// and let the logic below add the correct label.
-	if l.currentMap["release-notes-needed"] {
-		l.labelsToRemove["release-notes-needed"] = true
+	if l.currentMap["release-note-needed"] {
+		l.labelsToRemove["release-note-needed"] = true
 	}
 
 	// validate the release note block is present

--- a/internal/labeler/labeler_test.go
+++ b/internal/labeler/labeler_test.go
@@ -468,22 +468,22 @@ func TestProcessPR_LabelMigrationTableDriven(t *testing.T) {
 			prNum: 101,
 			initialLabels: []*github.Label{
 				{Name: github.Ptr("kind/bug_fix")},
-				{Name: github.Ptr("release-notes-needed")},
+				{Name: github.Ptr("release-note-needed")},
 			},
 			prBody:                 "/kind fix\\n```release-note\\nValid note\\n```",
 			expectedLabelsToAdd:    []string{"kind/fix", "release-note"},
-			expectedLabelsToRemove: []string{"kind/bug_fix", "release-notes-needed"},
+			expectedLabelsToRemove: []string{"kind/bug_fix", "release-note-needed"},
 		},
 		{
 			name:  "Deprecated_Feature_To_New_Feature",
 			prNum: 106,
 			initialLabels: []*github.Label{
 				{Name: github.Ptr("kind/new_feature")},
-				{Name: github.Ptr("release-notes-needed")},
+				{Name: github.Ptr("release-note-needed")},
 			},
 			prBody:                 "/kind new_feature\\n```release-note\\nValid note\\n```",
 			expectedLabelsToAdd:    []string{"kind/feature", "release-note"},
-			expectedLabelsToRemove: []string{"kind/new_feature", "release-notes-needed"},
+			expectedLabelsToRemove: []string{"kind/new_feature", "release-note-needed"},
 		},
 	}
 


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

The migration logic added in #10 was referencing the non-existent release-notes-needed label. This commit updates the logic to use the correct label name.

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bug_fix
/kind design
/kind cleanup
/kind deprecation
/kind documentation
/kind flake
/kind new_feature
```
-->

/kind fix

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
Fix references to the non-existent release-notes-needed label in the migration logic.
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->

https://github.com/kgateway-dev/kgateway/pull/11163