### PR TITLE
pkg,internal: Add 'install' and 'bump' as valid kind types

### DIFF
--- a/internal/labeler/labeler_test.go
+++ b/internal/labeler/labeler_test.go
@@ -507,12 +507,40 @@ func TestProcessPR_LabelMigrationTableDriven(t *testing.T) {
 			name:  "Deprecated_Feature_To_New_Feature",
 			prNum: 106,
 			initialLabels: []*github.Label{
-				{Name: github.Ptr("kind/new_feature")},
-				{Name: github.Ptr("release-note-needed")},
+				{Name: github.Ptr(fmt.Sprintf("kind/%s", kinds.DeprecatedNewFeature))},
+				{Name: github.Ptr(labels.DeprecatedReleaseNoteLabel)},
 			},
-			prBody:                 "/kind new_feature\\n```release-note\\nValid note\\n```",
-			expectedLabelsToAdd:    []string{"kind/feature", "release-note"},
-			expectedLabelsToRemove: []string{"kind/new_feature", "release-note-needed"},
+			prBody: "/kind new_feature\\n```release-note\\nValid note\\n```",
+			expectedLabelsToAdd: []string{
+				fmt.Sprintf("kind/%s", kinds.Feature),
+				labels.ReleaseNoteLabel,
+			},
+			expectedLabelsToRemove: []string{
+				fmt.Sprintf("kind/%s", kinds.DeprecatedNewFeature),
+				labels.DeprecatedReleaseNoteLabel,
+			},
+		},
+		{
+			name:          "Install_Kind_Label",
+			prNum:         107,
+			initialLabels: []*github.Label{},
+			prBody:        "/kind install\\n```release-note\\nUpdated Helm chart\\n```",
+			expectedLabelsToAdd: []string{
+				fmt.Sprintf("kind/%s", kinds.Install),
+				labels.ReleaseNoteLabel,
+			},
+			expectedLabelsToRemove: []string{},
+		},
+		{
+			name:          "Bump_Kind_Label",
+			prNum:         108,
+			initialLabels: []*github.Label{},
+			prBody:        "/kind bump\\n```release-note\\nUpdated dependencies\\n```",
+			expectedLabelsToAdd: []string{
+				fmt.Sprintf("kind/%s", kinds.Bump),
+				labels.ReleaseNoteLabel,
+			},
+			expectedLabelsToRemove: []string{},
 		},
 	}
 

--- a/pkg/kinds/kinds.go
+++ b/pkg/kinds/kinds.go
@@ -17,6 +17,10 @@ const (
 	Cleanup = "cleanup"
 	// Flake is a kind label that indicates the PR is a flake.
 	Flake = "flake"
+	// Install is a kind label that indicates the PR affects the installation of the product.
+	Install = "install"
+	// Bump is a kind label that indicates the PR is a dependency bump.
+	Bump = "bump"
 
 	// DeprecatedNewFeature is a deprecated kind label that indicates the PR is a new feature.
 	DeprecatedNewFeature = "new_feature"
@@ -34,6 +38,8 @@ var SupportedKinds = map[string]bool{
 	Documentation:  true,
 	Cleanup:        true,
 	Flake:          true,
+	Install:        true,
+	Bump:           true,
 }
 
 // DeprecatedKindMap maps old kind values to their new equivalents.


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

Enable PR authors to specify install and bump kinds

This PR adds support for two new kind labels to better categorize PRs:

- `kind/install`: For PRs that affect the installation of the product (e.g., Helm chart updates)
- `kind/bump`: For PRs that update critical dependencies (e.g. gateway-api)

No changes to the core labeling logic were required as the existing
infrastructure already handles new kind types through the `SupportedKinds` map.

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bug_fix
/kind design
/kind cleanup
/kind deprecation
/kind documentation
/kind flake
/kind new_feature
```
-->

/kind feature

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
Added support for two new kind labels:
- `kind/install`: For PRs that affect product installation (e.g., Helm chart updates)
- `kind/bump`: For PRs that update dependencies
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
