### PR TITLE
ci: allow /kind test as a supported PR kind

### DIFF
--- a/internal/labeler/labeler_test.go
+++ b/internal/labeler/labeler_test.go
@@ -542,6 +542,17 @@ func TestProcessPR_LabelMigrationTableDriven(t *testing.T) {
 			},
 			expectedLabelsToRemove: []string{},
 		},
+		{
+			name:          "Test_Kind_Label",
+			prNum:         109,
+			initialLabels: []*github.Label{},
+			prBody:        "/kind test\\n```release-note\\nAdded unit tests\\n```",
+			expectedLabelsToAdd: []string{
+				fmt.Sprintf("kind/%s", kinds.Test),
+				labels.ReleaseNoteLabel,
+			},
+			expectedLabelsToRemove: []string{},
+		},
 	}
 
 	for _, tc := range tt {

--- a/pkg/kinds/kinds.go
+++ b/pkg/kinds/kinds.go
@@ -21,6 +21,8 @@ const (
 	Install = "install"
 	// Bump is a kind label that indicates the PR is a dependency bump.
 	Bump = "bump"
+	// Test is a kind label that indicates the PR is a test.
+	Test = "test"
 
 	// DeprecatedNewFeature is a deprecated kind label that indicates the PR is a new feature.
 	DeprecatedNewFeature = "new_feature"
@@ -40,6 +42,7 @@ var SupportedKinds = map[string]bool{
 	Flake:          true,
 	Install:        true,
 	Bump:           true,
+	Test:           true,
 }
 
 // DeprecatedKindMap maps old kind values to their new equivalents.


### PR DESCRIPTION
## Description

This PR adds support for `test` as a valid PR kind in the pr-kind-labeler tool.

Previously, `/kind test` was rejected at the tool level as an invalid kind, even though contributors commonly use it for PRs that add or modify tests (unit, integration, or E2E), and downstream repositories already rely on this usage.

This change updates the tool’s source of truth to recognize `test` as a supported kind and adds unit test coverage to ensure `/kind test` is correctly processed and labeled.

---

## Change Type

/kind ci

---

## Changelog

NONE

---

## Additional Notes

- Adds `test` to the list of supported PR kinds in the tool  
- Adds unit test coverage to validate `/kind test` behavior  
- Ensures a `kind/test` label is created and `do-not-merge/kind-invalid` is not applied  
- No breaking changes and no impact on existing kinds  
- Improves labeling accuracy and contributor experience


