### PR TITLE
internal: Add naive opt-in changelog checks

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -9,9 +9,19 @@ inputs:
     description: "Enforce that the Description section in the PR body is filled out"
     default: "true"
     required: false
+  enforce_release_note_quality:
+    description: "Enforce naive publication-ready release note checks"
+    default: "false"
+    required: false
+  enforce_changelog_kind_exclusivity:
+    description: "Enforce at most one changelog kind per PR"
+    default: "false"
+    required: false
 runs:
   using: "docker"
   image: "Dockerfile"
   args:
     - ${{ inputs.token }}
     - ${{ inputs.enforce_description }}
+    - ${{ inputs.enforce_release_note_quality }}
+    - ${{ inputs.enforce_changelog_kind_exclusivity }}

--- a/internal/labeler/labeler.go
+++ b/internal/labeler/labeler.go
@@ -25,31 +25,62 @@ var (
 	// descriptionRE captures content under the # Description heading until the next level-1 heading or end of string.
 	// Only stops at # followed by space (level-1), not ## or ### (level-2+)
 	descriptionRE = regexp.MustCompile(`(?sm)^#[ \t]*Description[ \t]*\n(.*?)(?:^#[ \t]|\z)`)
+
+	conventionalCommitPrefixRE = regexp.MustCompile(`(?i)^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([^)]+\))?!?:\s*`)
+	breakingChangePrefixRE     = regexp.MustCompile(`(?i)^BREAKING( CHANGE)?:\s*`)
+	markdownBulletRE           = regexp.MustCompile(`(?m)^[ \t]*(?:[-*+][ \t]+|[0-9]+[.)][ \t]+)`)
+	markdownHeadingRE          = regexp.MustCompile(`(?m)^[ \t]*#{1,6}[ \t]+`)
+	fencedCodeBlockRE          = regexp.MustCompile("(?m)^[ \t]*(?:```|~~~)")
+	thisPRRE                   = regexp.MustCompile(`(?i)\bthis[ \t]+pr\b`)
 )
+
+const maxReleaseNoteLength = 500
+
+var changelogKinds = map[string]bool{
+	kinds.BreakingChange: true,
+	kinds.Feature:        true,
+	kinds.Fix:            true,
+	kinds.Deprecation:    true,
+	kinds.Install:        true,
+	kinds.Documentation:  true,
+	kinds.Bump:           true,
+}
 
 // labeler handles PR labeling operations.
 type labeler struct {
-	client             *github.Client
-	owner              string
-	repo               string
-	prNum              int
-	labelsToAdd        map[string]bool
-	labelsToRemove     map[string]bool
-	currentMap         map[string]bool
-	enforceDescription bool
+	client                          *github.Client
+	owner                           string
+	repo                            string
+	prNum                           int
+	labelsToAdd                     map[string]bool
+	labelsToRemove                  map[string]bool
+	currentMap                      map[string]bool
+	enforceDescription              bool
+	enforceReleaseNoteQuality       bool
+	enforceChangelogKindExclusivity bool
 }
 
 // New creates a new Labeler instance.
-func New(client *github.Client, owner, repo string, prNum int, enforceDescription bool) *labeler {
+func New(client *github.Client, owner, repo string, prNum int, enforceDescription bool, validationFlags ...bool) *labeler {
+	enforceReleaseNoteQuality := false
+	if len(validationFlags) > 0 {
+		enforceReleaseNoteQuality = validationFlags[0]
+	}
+	enforceChangelogKindExclusivity := false
+	if len(validationFlags) > 1 {
+		enforceChangelogKindExclusivity = validationFlags[1]
+	}
 	return &labeler{
-		client:             client,
-		owner:              owner,
-		repo:               repo,
-		prNum:              prNum,
-		labelsToAdd:        map[string]bool{},
-		labelsToRemove:     map[string]bool{},
-		currentMap:         map[string]bool{},
-		enforceDescription: enforceDescription,
+		client:                          client,
+		owner:                           owner,
+		repo:                            repo,
+		prNum:                           prNum,
+		labelsToAdd:                     map[string]bool{},
+		labelsToRemove:                  map[string]bool{},
+		currentMap:                      map[string]bool{},
+		enforceDescription:              enforceDescription,
+		enforceReleaseNoteQuality:       enforceReleaseNoteQuality,
+		enforceChangelogKindExclusivity: enforceChangelogKindExclusivity,
 	}
 }
 
@@ -140,10 +171,32 @@ func (l *labeler) verifyKinds(extractedKinds map[string]bool) error {
 		}
 		return fmt.Errorf("invalid /kind %q detected, labeling %q. supported kinds: %v", k, labels.InvalidKindLabel, slices.Collect(maps.Keys(kinds.SupportedKinds)))
 	}
+	if l.enforceChangelogKindExclusivity {
+		if invalidKinds := invalidChangelogKindCombination(extractedKinds); len(invalidKinds) > 0 {
+			if !l.currentMap[labels.InvalidKindLabel] {
+				l.labelsToAdd[labels.InvalidKindLabel] = true
+			}
+			return fmt.Errorf("multiple changelog /kind labels detected: %v. Choose exactly one changelog kind per PR so the generated changelog has one category. Changelog kinds are: %v", invalidKinds, slices.Collect(maps.Keys(changelogKinds)))
+		}
+	}
 	if l.currentMap[labels.InvalidKindLabel] {
 		l.labelsToRemove[labels.InvalidKindLabel] = true
 	}
 	return nil
+}
+
+func invalidChangelogKindCombination(extractedKinds map[string]bool) []string {
+	var found []string
+	for k := range extractedKinds {
+		if changelogKinds[k] {
+			found = append(found, k)
+		}
+	}
+	sort.Strings(found)
+	if len(found) <= 1 {
+		return nil
+	}
+	return found
 }
 
 // syncKindLabels synchronizes the PR labels with the extracted kinds
@@ -204,15 +257,7 @@ func (l *labeler) processReleaseNotes(body string) error {
 	entry := strings.TrimSpace(match[1])
 	switch {
 	case entry == "":
-		if !l.currentMap[labels.InvalidReleaseNoteLabel] {
-			l.labelsToAdd[labels.InvalidReleaseNoteLabel] = true
-		}
-		if l.currentMap[labels.ReleaseNoteLabel] {
-			l.labelsToRemove[labels.ReleaseNoteLabel] = true
-		}
-		if l.currentMap[labels.ReleaseNoteNoneLabel] {
-			l.labelsToRemove[labels.ReleaseNoteNoneLabel] = true
-		}
+		l.markInvalidReleaseNote()
 		return fmt.Errorf("missing or empty ```release-note``` block; please add your line or 'NONE'")
 	case strings.EqualFold(entry, "NONE"):
 		// handle special NONE case
@@ -226,6 +271,12 @@ func (l *labeler) processReleaseNotes(body string) error {
 			l.labelsToRemove[labels.ReleaseNoteLabel] = true
 		}
 	default:
+		if l.enforceReleaseNoteQuality {
+			if err := validateReleaseNote(entry); err != nil {
+				l.markInvalidReleaseNote()
+				return err
+			}
+		}
 		// validate release note was found
 		if !l.currentMap[labels.ReleaseNoteLabel] {
 			l.labelsToAdd[labels.ReleaseNoteLabel] = true
@@ -238,6 +289,56 @@ func (l *labeler) processReleaseNotes(body string) error {
 		}
 	}
 	return nil
+}
+
+func (l *labeler) markInvalidReleaseNote() {
+	if !l.currentMap[labels.InvalidReleaseNoteLabel] {
+		l.labelsToAdd[labels.InvalidReleaseNoteLabel] = true
+	}
+	if l.currentMap[labels.ReleaseNoteLabel] {
+		l.labelsToRemove[labels.ReleaseNoteLabel] = true
+	}
+	if l.currentMap[labels.ReleaseNoteNoneLabel] {
+		l.labelsToRemove[labels.ReleaseNoteNoneLabel] = true
+	}
+}
+
+func validateReleaseNote(entry string) error {
+	var reasons []string
+	if len(entry) > maxReleaseNoteLength {
+		reasons = append(reasons, fmt.Sprintf("must be %d characters or fewer", maxReleaseNoteLength))
+	}
+	for _, r := range entry {
+		if r > 127 {
+			reasons = append(reasons, "must use ASCII characters only")
+			break
+		}
+	}
+	if strings.Contains(entry, "\n") {
+		reasons = append(reasons, "must be one plain sentence without blank lines or multiple paragraphs")
+	}
+	if markdownBulletRE.MatchString(entry) {
+		reasons = append(reasons, "must not use markdown bullets")
+	}
+	if markdownHeadingRE.MatchString(entry) {
+		reasons = append(reasons, "must not use markdown headings")
+	}
+	if fencedCodeBlockRE.MatchString(entry) {
+		reasons = append(reasons, "must not include fenced code blocks")
+	}
+	if conventionalCommitPrefixRE.MatchString(entry) {
+		reasons = append(reasons, "must not start with a conventional commit prefix like fix: or feat(helm)!:")
+	}
+	if breakingChangePrefixRE.MatchString(entry) {
+		reasons = append(reasons, "must not start with a BREAKING or BREAKING CHANGE prefix")
+	}
+	if thisPRRE.MatchString(entry) {
+		reasons = append(reasons, "must describe the user-facing change, not refer to this PR")
+	}
+	if len(reasons) == 0 {
+		return nil
+	}
+	return fmt.Errorf("invalid release note: %s. Release notes are copied verbatim into public changelogs; write one plain, user-facing sentence or use 'NONE'", strings.Join(reasons, "; "))
 }
 
 // processDescription handles the description validation and labeling

--- a/internal/labeler/labeler_test.go
+++ b/internal/labeler/labeler_test.go
@@ -349,6 +349,240 @@ func TestProcessPR_ReleaseNoteNone(t *testing.T) {
 	}
 }
 
+func TestValidateReleaseNoteQuality(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		entry     string
+		wantError string
+	}{
+		{
+			name:  "valid plain release note",
+			entry: "Fixed route status updates when backend services are recreated.",
+		},
+		{
+			name:      "fix prefix rejected",
+			entry:     "fix: update route status.",
+			wantError: "conventional commit prefix",
+		},
+		{
+			name:      "scoped breaking conventional prefix rejected",
+			entry:     "feat(helm)!: add listener policy support.",
+			wantError: "conventional commit prefix",
+		},
+		{
+			name:      "breaking change prefix rejected",
+			entry:     "BREAKING CHANGE: Route policy defaults now require explicit backend refs.",
+			wantError: "BREAKING",
+		},
+		{
+			name:      "emoji rejected",
+			entry:     "Added listener policy support 🚀",
+			wantError: "ASCII",
+		},
+		{
+			name:      "bullet list rejected",
+			entry:     "- Added listener policy support.",
+			wantError: "markdown bullets",
+		},
+		{
+			name:      "heading rejected",
+			entry:     "## Added listener policy support.",
+			wantError: "markdown headings",
+		},
+		{
+			name:      "fenced code block rejected",
+			entry:     "```go\nfmt.Println(\"listener policy\")\n```",
+			wantError: "fenced code blocks",
+		},
+		{
+			name:      "blank line rejected",
+			entry:     "Added listener policy support.\n\nUpdated Helm values.",
+			wantError: "blank lines",
+		},
+		{
+			name:      "this PR rejected",
+			entry:     "This PR adds listener policy support.",
+			wantError: "this PR",
+		},
+		{
+			name:      "max length rejected",
+			entry:     strings.Repeat("a", maxReleaseNoteLength+1),
+			wantError: "characters or fewer",
+		},
+		{
+			name:  "NONE is handled before quality validation",
+			entry: "NONE",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateReleaseNote(tc.entry)
+			if tc.wantError == "" {
+				if err != nil {
+					t.Fatalf("expected no error, got %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.wantError) {
+				t.Fatalf("expected error containing %q, got %v", tc.wantError, err)
+			}
+			if !strings.Contains(err.Error(), "copied verbatim into public changelogs") {
+				t.Fatalf("expected public changelog guidance, got %v", err)
+			}
+		})
+	}
+}
+
+func TestInvalidReleaseNoteQualityLabelsPR(t *testing.T) {
+	expectedLabelsToAdd := []string{
+		labels.InvalidReleaseNoteLabel,
+	}
+	sort.Strings(expectedLabelsToAdd)
+	expectedLabelsToRemove := []string{
+		labels.ReleaseNoteLabel,
+		labels.ReleaseNoteNoneLabel,
+	}
+	sort.Strings(expectedLabelsToRemove)
+
+	actualLabelsAdded, actualLabelsRemoved, err := processPRForTest(t,
+		[]*github.Label{
+			{Name: github.Ptr(fmt.Sprintf("kind/%s", kinds.Fix))},
+			{Name: github.Ptr(labels.ReleaseNoteLabel)},
+			{Name: github.Ptr(labels.ReleaseNoteNoneLabel)},
+		},
+		"/kind fix\n```release-note\nfix: repaired route status updates.\n```",
+		true,
+	)
+	if err == nil || !strings.Contains(err.Error(), "copied verbatim into public changelogs") {
+		t.Fatalf("expected release-note quality error, got %v", err)
+	}
+	if !reflect.DeepEqual(actualLabelsAdded, expectedLabelsToAdd) {
+		t.Fatalf("Expected labels to be added %v, got %v", expectedLabelsToAdd, actualLabelsAdded)
+	}
+	sort.Strings(actualLabelsRemoved)
+	if !reflect.DeepEqual(actualLabelsRemoved, expectedLabelsToRemove) {
+		t.Fatalf("Expected labels to be removed %v, got %v", expectedLabelsToRemove, actualLabelsRemoved)
+	}
+}
+
+func TestInvalidChangelogKindCombinations(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		body      string
+		wantAdd   []string
+		wantError string
+	}{
+		{
+			name:      "multiple changelog kinds rejected",
+			body:      "/kind feature\n/kind fix\n```release-note\nImproved route status updates.\n```",
+			wantAdd:   []string{labels.InvalidKindLabel, labels.ReleaseNoteLabel},
+			wantError: "multiple changelog /kind labels",
+		},
+		{
+			name:      "breaking change plus fix rejected",
+			body:      "/kind breaking_change\n/kind fix\n```release-note\nChanged route policy defaults.\n```",
+			wantAdd:   []string{labels.InvalidKindLabel, labels.ReleaseNoteLabel},
+			wantError: "multiple changelog /kind labels",
+		},
+		{
+			name:    "cleanup plus flake with NONE accepted",
+			body:    "/kind cleanup\n/kind flake\n```release-note\nNONE\n```",
+			wantAdd: []string{fmt.Sprintf("kind/%s", kinds.Cleanup), fmt.Sprintf("kind/%s", kinds.Flake), labels.ReleaseNoteNoneLabel},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			actualLabelsAdded, _, err := processPRForTest(t, []*github.Label{}, tc.body, false, true)
+			if tc.wantError == "" {
+				if err != nil {
+					t.Fatalf("expected no error, got %v", err)
+				}
+			} else if err == nil || !strings.Contains(err.Error(), tc.wantError) {
+				t.Fatalf("expected error containing %q, got %v", tc.wantError, err)
+			}
+			sort.Strings(tc.wantAdd)
+			if !reflect.DeepEqual(actualLabelsAdded, tc.wantAdd) {
+				t.Fatalf("Expected labels to be added %v, got %v", tc.wantAdd, actualLabelsAdded)
+			}
+		})
+	}
+}
+
+func TestStrictChangelogValidationDefaultsOff(t *testing.T) {
+	expectedLabelsToAdd := []string{
+		fmt.Sprintf("kind/%s", kinds.Feature),
+		fmt.Sprintf("kind/%s", kinds.Fix),
+		labels.ReleaseNoteLabel,
+	}
+	sort.Strings(expectedLabelsToAdd)
+
+	actualLabelsAdded, _, err := processPRForTest(t,
+		[]*github.Label{},
+		"/kind feature\n/kind fix\n```release-note\nfix: repaired route status updates.\n```",
+	)
+	if err != nil {
+		t.Fatalf("expected no error when strict changelog validation is not enabled, got %v", err)
+	}
+	if !reflect.DeepEqual(actualLabelsAdded, expectedLabelsToAdd) {
+		t.Fatalf("Expected labels to be added %v, got %v", expectedLabelsToAdd, actualLabelsAdded)
+	}
+}
+
+func TestReleaseNoteQualityFlagDoesNotEnforceKindExclusivity(t *testing.T) {
+	expectedLabelsToAdd := []string{
+		fmt.Sprintf("kind/%s", kinds.Feature),
+		fmt.Sprintf("kind/%s", kinds.Fix),
+		labels.ReleaseNoteLabel,
+	}
+	sort.Strings(expectedLabelsToAdd)
+
+	actualLabelsAdded, _, err := processPRForTest(t,
+		[]*github.Label{},
+		"/kind feature\n/kind fix\n```release-note\nImproved route status updates.\n```",
+		true,
+		false,
+	)
+	if err != nil {
+		t.Fatalf("expected no error when only release note quality validation is enabled, got %v", err)
+	}
+	if !reflect.DeepEqual(actualLabelsAdded, expectedLabelsToAdd) {
+		t.Fatalf("Expected labels to be added %v, got %v", expectedLabelsToAdd, actualLabelsAdded)
+	}
+}
+
+func TestKindExclusivityFlagDoesNotEnforceReleaseNoteQuality(t *testing.T) {
+	expectedLabelsToAdd := []string{
+		fmt.Sprintf("kind/%s", kinds.Fix),
+		labels.ReleaseNoteLabel,
+	}
+	sort.Strings(expectedLabelsToAdd)
+
+	actualLabelsAdded, _, err := processPRForTest(t,
+		[]*github.Label{},
+		"/kind fix\n```release-note\nfix: repaired route status updates.\n```",
+		false,
+		true,
+	)
+	if err != nil {
+		t.Fatalf("expected no error when only changelog kind exclusivity is enabled, got %v", err)
+	}
+	if !reflect.DeepEqual(actualLabelsAdded, expectedLabelsToAdd) {
+		t.Fatalf("Expected labels to be added %v, got %v", expectedLabelsToAdd, actualLabelsAdded)
+	}
+}
+
 func TestProcessPR_EditedToInvalid(t *testing.T) {
 	expectedLabelsToAdd := []string{
 		labels.InvalidReleaseNoteLabel,
@@ -1033,4 +1267,60 @@ func TestProcessPR_ValidDescriptionWithSubheadings(t *testing.T) {
 	if !reflect.DeepEqual(actualLabelsRemoved, expectedLabelsToRemove) {
 		t.Fatalf("Expected labels to be removed %v, got %v", expectedLabelsToRemove, actualLabelsRemoved)
 	}
+}
+
+func processPRForTest(t *testing.T, initialLabels []*github.Label, prBody string, validationFlags ...bool) ([]string, []string, error) {
+	t.Helper()
+
+	var actualLabelsAdded []string = make([]string, 0)
+	var actualLabelsRemoved []string = make([]string, 0)
+	const prNum = 900
+	enforceReleaseNoteQuality := false
+	if len(validationFlags) > 0 {
+		enforceReleaseNoteQuality = validationFlags[0]
+	}
+	enforceChangelogKindExclusivity := false
+	if len(validationFlags) > 1 {
+		enforceChangelogKindExclusivity = validationFlags[1]
+	}
+
+	httpClient := mock.NewMockedHTTPClient(
+		mock.WithRequestMatch(
+			mock.GetReposIssuesLabelsByOwnerByRepoByIssueNumber,
+			initialLabels,
+		),
+		mock.WithRequestMatchHandler(
+			mock.PostReposIssuesLabelsByOwnerByRepoByIssueNumber,
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if err := json.NewDecoder(r.Body).Decode(&actualLabelsAdded); err != nil {
+					t.Fatalf("AddLabels Handler: failed to decode body: %v", err)
+				}
+				sort.Strings(actualLabelsAdded)
+				responseLabels := make([]*github.Label, len(actualLabelsAdded))
+				for i, name := range actualLabelsAdded {
+					responseLabels[i] = &github.Label{Name: github.Ptr(name)}
+				}
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(responseLabels)
+			}),
+		),
+		mock.WithRequestMatchHandler(
+			mock.DeleteReposIssuesLabelsByOwnerByRepoByIssueNumberByName,
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				pathPrefix := fmt.Sprintf("/repos/%s/%s/issues/%d/labels/", "owner", "repo", prNum)
+				labelNameSegment := strings.TrimPrefix(r.URL.Path, pathPrefix)
+				decodedLabelName, err := url.PathUnescape(labelNameSegment)
+				if err != nil {
+					t.Fatalf("Failed to unescape label name segment '%s': %v", labelNameSegment, err)
+				}
+				actualLabelsRemoved = append(actualLabelsRemoved, decodedLabelName)
+				sort.Strings(actualLabelsRemoved)
+				w.WriteHeader(http.StatusNoContent)
+			}),
+		),
+	)
+
+	l := New(github.NewClient(httpClient), "owner", "repo", prNum, false, enforceReleaseNoteQuality, enforceChangelogKindExclusivity)
+	err := l.ProcessPR(context.Background(), prBody, true)
+	return actualLabelsAdded, actualLabelsRemoved, err
 }

--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ func main() {
 	cmd := cobra.Command{
 		Use:          "pr-kind-labeler",
 		Short:        "Sync /kind commands in PR body to GitHub labels and enforce changelog notes",
-		Args:         cobra.RangeArgs(1, 2),
+		Args:         cobra.RangeArgs(1, 4),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
@@ -38,6 +38,24 @@ func main() {
 				}
 			}
 
+			// parse enforce_release_note_quality flag (defaults to false)
+			enforceReleaseNoteQuality := false
+			if len(os.Args) > 3 {
+				enforceReleaseNoteQualityStr := os.Args[3]
+				if enforceReleaseNoteQualityStr == "true" {
+					enforceReleaseNoteQuality = true
+				}
+			}
+
+			// parse enforce_changelog_kind_exclusivity flag (defaults to false)
+			enforceChangelogKindExclusivity := false
+			if len(os.Args) > 4 {
+				enforceChangelogKindExclusivityStr := os.Args[4]
+				if enforceChangelogKindExclusivityStr == "true" {
+					enforceChangelogKindExclusivity = true
+				}
+			}
+
 			if ghprEnv := os.Getenv("GHPR"); ghprEnv != "" {
 				// You can manually test, like so:
 				// GHPR=kgateway-dev/kgateway/11221 go run . $GITHUB_API_TOKEN
@@ -52,7 +70,7 @@ func main() {
 				if err != nil {
 					return fmt.Errorf("invalid PR number: %w", err)
 				}
-				return manualTest(ctx, client, owner, repo, prNumInt, enforceDescription)
+				return manualTest(ctx, client, owner, repo, prNumInt, enforceDescription, enforceReleaseNoteQuality, enforceChangelogKindExclusivity)
 			}
 
 			eventPath := os.Getenv("GITHUB_EVENT_PATH")
@@ -70,7 +88,7 @@ func main() {
 			prNum := prEvent.GetNumber()
 			body := prEvent.GetPullRequest().GetBody()
 
-			l := labeler.New(client, owner, repo, prNum, enforceDescription)
+			l := labeler.New(client, owner, repo, prNum, enforceDescription, enforceReleaseNoteQuality, enforceChangelogKindExclusivity)
 			if err := l.ProcessPR(ctx, body, true); err != nil {
 				return err
 			}
@@ -83,7 +101,7 @@ func main() {
 	}
 }
 
-func manualTest(ctx context.Context, client *github.Client, owner, repo string, prNum int, enforceDescription bool) error {
+func manualTest(ctx context.Context, client *github.Client, owner, repo string, prNum int, enforceDescription bool, enforceReleaseNoteQuality bool, enforceChangelogKindExclusivity bool) error {
 
 	prResp, _, err := client.PullRequests.Get(ctx, owner, repo, prNum)
 	if err != nil {
@@ -91,6 +109,6 @@ func manualTest(ctx context.Context, client *github.Client, owner, repo string, 
 	}
 	body := prResp.GetBody()
 
-	l := labeler.New(client, owner, repo, prNum, enforceDescription)
+	l := labeler.New(client, owner, repo, prNum, enforceDescription, enforceReleaseNoteQuality, enforceChangelogKindExclusivity)
 	return l.ProcessPR(ctx, body, false)
 }


### PR DESCRIPTION
# Description

Adds opt-in validation for PR changelog hygiene without changing default action behavior. One new input enables naive publication-ready release note checks, and a separate input enables the stricter one-changelog-kind rule so teams can roll them out independently.

# Change Type

/kind feature

# Changelog

```release-note
Added opt-in release note quality and changelog kind exclusivity validation for PR labeling.
```

# Additional Notes

Verified with `go test ./...`.
