### PR TITLE
pkg,internal: Add test as a valid kind type

### DIFF
--- a/internal/labeler/labeler_test.go
+++ b/internal/labeler/labeler_test.go
@@ -497,6 +497,11 @@ func TestInvalidChangelogKindCombinations(t *testing.T) {
 			body:    "/kind cleanup\n/kind flake\n```release-note\nNONE\n```",
 			wantAdd: []string{fmt.Sprintf("kind/%s", kinds.Cleanup), fmt.Sprintf("kind/%s", kinds.Flake), labels.ReleaseNoteNoneLabel},
 		},
+		{
+			name:    "test with NONE accepted",
+			body:    "/kind test\n```release-note\nNONE\n```",
+			wantAdd: []string{fmt.Sprintf("kind/%s", kinds.Test), labels.ReleaseNoteNoneLabel},
+		},
 	}
 
 	for _, tc := range tests {

--- a/pkg/kinds/kinds.go
+++ b/pkg/kinds/kinds.go
@@ -21,6 +21,8 @@ const (
 	Install = "install"
 	// Bump is a kind label that indicates the PR is a dependency bump.
 	Bump = "bump"
+	// Test is a kind label that indicates the PR affects tests.
+	Test = "test"
 
 	// DeprecatedNewFeature is a deprecated kind label that indicates the PR is a new feature.
 	DeprecatedNewFeature = "new_feature"
@@ -40,6 +42,7 @@ var SupportedKinds = map[string]bool{
 	Flake:          true,
 	Install:        true,
 	Bump:           true,
+	Test:           true,
 }
 
 // DeprecatedKindMap maps old kind values to their new equivalents.


### PR DESCRIPTION
# Description

Add `test` as a supported `/kind` value so PRs can use `/kind test` and receive the `kind/test` label without being marked invalid.

# Change Type

/kind feature

# Changelog

```release-note
NONE
```

# Additional Notes

Verified with `go test ./...`.